### PR TITLE
Add support for LLVM 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,9 @@ find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
-if((${LLVM_PACKAGE_VERSION} VERSION_LESS "9.0.0")
+if(((${LLVM_PACKAGE_VERSION} VERSION_LESS "9.0.0")
    OR (${LLVM_PACKAGE_VERSION} VERSION_GREATER_EQUAL "12"))
+   AND (NOT (${LLVM_PACKAGE_VERSION} VERSION_EQUAL "13")))
   message(FATAL_ERROR "Only LLVM 9 through 11 are supported.")
 endif()
 

--- a/main.cpp
+++ b/main.cpp
@@ -316,7 +316,6 @@ class ConstexprVarDeclFunctionASTVisitor
       // Is init an integral constant expression
       if (!var->checkInitIsICE())
         return true;
-      }
 #endif
 
       // Does the init function use dependent values


### PR DESCRIPTION
Add support for LLVM 13.0.0. I only updated the APIs that have been changed in LLVM 13 based on my understanding, and more tests are required to ensure it works correctly.